### PR TITLE
Add create expense functionality and restyle section

### DIFF
--- a/app/(dashboard)/properties/[id]/actions.ts
+++ b/app/(dashboard)/properties/[id]/actions.ts
@@ -2,9 +2,9 @@
 
 import prisma from '@/lib/prisma';
 import { Frequency } from '@prisma/client';
-import { revalidatePath, revalidateTag } from 'next/cache';
+import { revalidatePath } from 'next/cache';
 
-export async function addExpense(formData: FormData) {
+export async function createExpense(formData: FormData) {
   const propertyId = Number(formData.get('propertyId'));
   const name = formData.get('name') as string;
   const amount = parseFloat(formData.get('amount') as string);
@@ -37,12 +37,12 @@ export async function addExpense(formData: FormData) {
       frequency: newExpense.frequency
     };
   } catch (error) {
-    console.error('Database error:', error);
-    throw new Error('Failed to add the expense. Please try again.');
+    console.error(error);
+    throw new Error('Failed to create the expense. Please try again.');
   }
 }
 
-export async function editExpense(formData: FormData) {
+export async function updateExpense(formData: FormData) {
   const id = Number(formData.get('id'));
   const name = formData.get('name') as string;
   const amount = parseFloat(formData.get('amount') as string);
@@ -93,8 +93,6 @@ export async function deleteExpense(id: number) {
     });
 
     revalidatePath('/properties/[id]/edit', 'page');
-
-    return { message: 'Expense deleted successfully.', status: 200 };
   } catch (error) {
     console.error('Error deleting expense:', error);
     throw new Error('Failed to delete the expense. Please try again.');

--- a/app/(dashboard)/properties/[id]/components/expense-form.test.tsx
+++ b/app/(dashboard)/properties/[id]/components/expense-form.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ExpenseForm from './expense-form';
+import { describe, it, vi, expect, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+
+describe('ExpenseForm', () => {
+  const mockPrimaryAction = {
+    label: 'Save',
+    action: vi.fn()
+  };
+
+  const mockOnCancel = vi.fn();
+
+  const initialData = {
+    name: 'Utilities',
+    amount: 150,
+    frequency: 'monthly'
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders form fields with initial values', () => {
+    render(
+      <ExpenseForm
+        initialData={initialData}
+        onCancel={mockOnCancel}
+        primaryAction={mockPrimaryAction}
+      />
+    );
+
+    expect(screen.getByLabelText(/name/i)).toHaveValue('Utilities');
+    expect(screen.getByLabelText(/amount/i)).toHaveValue(150);
+    expect(screen.getByLabelText(/frequency/i)).toHaveValue('monthly');
+  });
+
+  it('updates form state when inputs are changed', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExpenseForm
+        initialData={initialData}
+        onCancel={mockOnCancel}
+        primaryAction={mockPrimaryAction}
+      />
+    );
+
+    const nameInput = screen.getByLabelText(/name/i);
+    const amountInput = screen.getByLabelText(/amount/i);
+    const frequencySelect = screen.getByLabelText(/frequency/i);
+
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Updated Utilities');
+    await user.clear(amountInput);
+    await user.type(amountInput, '200');
+    await user.selectOptions(frequencySelect, 'yearly');
+
+    expect(nameInput).toHaveValue('Updated Utilities');
+    expect(amountInput).toHaveValue(200);
+    expect(frequencySelect).toHaveValue('yearly');
+  });
+
+  it('submits the form and calls primaryAction', async () => {
+    const user = userEvent.setup();
+    mockPrimaryAction.action.mockResolvedValue(undefined);
+
+    render(
+      <ExpenseForm
+        initialData={initialData}
+        onCancel={mockOnCancel}
+        primaryAction={mockPrimaryAction}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mockPrimaryAction.action).toHaveBeenCalledWith(
+        expect.any(FormData)
+      );
+    });
+  });
+
+  it('displays error message on submission failure', async () => {
+    const user = userEvent.setup();
+    mockPrimaryAction.action.mockRejectedValue(
+      new Error('Failed to save expense')
+    );
+
+    render(
+      <ExpenseForm
+        initialData={initialData}
+        onCancel={mockOnCancel}
+        primaryAction={mockPrimaryAction}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to save expense/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExpenseForm
+        initialData={initialData}
+        onCancel={mockOnCancel}
+        primaryAction={mockPrimaryAction}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(mockOnCancel).toHaveBeenCalled();
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/(dashboard)/properties/[id]/components/expense-form.tsx
+++ b/app/(dashboard)/properties/[id]/components/expense-form.tsx
@@ -4,8 +4,8 @@ import { Button } from '@/components/ui/button';
 
 interface Props {
   initialData: {
-    name: string;
-    amount: number;
+    name?: string;
+    amount?: number;
     frequency: string;
   };
   onCancel: () => void;
@@ -30,8 +30,8 @@ function ExpenseForm({ initialData, onCancel, primaryAction }: Props) {
     setIsLoading(true);
 
     const formData = new FormData();
-    formData.set('name', formState.name);
-    formData.set('amount', formState.amount.toString());
+    formData.set('name', formState?.name ?? '');
+    formData.set('amount', formState?.amount?.toString() ?? '');
     formData.set('frequency', formState.frequency);
 
     try {
@@ -58,6 +58,7 @@ function ExpenseForm({ initialData, onCancel, primaryAction }: Props) {
           name="name"
           value={formState.name}
           onChange={(e) => handleInputChange('name', e.target.value)}
+          placeholder="Enter expense name"
           className="border p-1 w-full text-sm"
         />
       </div>
@@ -74,6 +75,7 @@ function ExpenseForm({ initialData, onCancel, primaryAction }: Props) {
           name="amount"
           value={formState.amount}
           onChange={(e) => handleInputChange('amount', e.target.value)}
+          placeholder="Enter expense amount"
           className="border p-1 w-full text-sm"
           step="0.01"
         />

--- a/app/(dashboard)/properties/[id]/components/expense-form.tsx
+++ b/app/(dashboard)/properties/[id]/components/expense-form.tsx
@@ -1,0 +1,112 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  initialData: {
+    name: string;
+    amount: number;
+    frequency: string;
+  };
+  onCancel: () => void;
+  primaryAction: {
+    label: string;
+    action: (formData: FormData) => Promise<void>;
+  };
+}
+
+function ExpenseForm({ initialData, onCancel, primaryAction }: Props) {
+  const [formState, setFormState] = useState(initialData);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleInputChange = (field: keyof typeof formState, value: string) => {
+    setFormState((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setIsLoading(true);
+
+    const formData = new FormData();
+    formData.set('name', formState.name);
+    formData.set('amount', formState.amount.toString());
+    formData.set('frequency', formState.frequency);
+
+    try {
+      await primaryAction.action(formData);
+    } catch (error: Error | any) {
+      setError(error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form className="space-y-5 w-full" onSubmit={handleSubmit}>
+      <div>
+        <label
+          htmlFor="expense-name"
+          className="block text-sm mb-1 font-medium"
+        >
+          Name
+        </label>
+        <input
+          id="expense-name"
+          type="text"
+          name="name"
+          value={formState.name}
+          onChange={(e) => handleInputChange('name', e.target.value)}
+          className="border p-1 w-full text-sm"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="expense-amount"
+          className="block text-sm mb-1 font-medium"
+        >
+          Amount
+        </label>
+        <input
+          id="expense-amount"
+          type="number"
+          name="amount"
+          value={formState.amount}
+          onChange={(e) => handleInputChange('amount', e.target.value)}
+          className="border p-1 w-full text-sm"
+          step="0.01"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="expense-frequency"
+          className="block text-sm mb-1 font-medium"
+        >
+          Frequency
+        </label>
+        <select
+          id="expense-frequency"
+          name="frequency"
+          value={formState.frequency}
+          onChange={(e) => handleInputChange('frequency', e.target.value)}
+          className="border p-1 w-full text-sm"
+        >
+          <option value="monthly">Monthly</option>
+          <option value="yearly">Yearly</option>
+        </select>
+      </div>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <div className="flex space-x-2">
+        <Button type="submit" size="sm" variant="default" disabled={isLoading}>
+          {isLoading ? 'Saving...' : primaryAction.label}
+        </Button>
+        <Button type="button" onClick={onCancel} size="sm" variant="outline">
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default ExpenseForm;

--- a/app/(dashboard)/properties/[id]/components/expense-list-item.tsx
+++ b/app/(dashboard)/properties/[id]/components/expense-list-item.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  onClick?: () => void;
+  className?: string;
+}
+
+function ExpenseListItem({ children, onClick, className }: Props) {
+  const classString =
+    className && className.trim().length ? ` ${className}` : '';
+
+  return (
+    <li
+      className={`flex justify-between items-center rounded-md border-b p-6 hover:bg-slate-100${classString}`}
+      onClick={onClick}
+    >
+      {children}
+    </li>
+  );
+}
+
+export default ExpenseListItem;

--- a/app/(dashboard)/properties/[id]/components/expense-list-item.tsx
+++ b/app/(dashboard)/properties/[id]/components/expense-list-item.tsx
@@ -14,7 +14,7 @@ function ExpenseListItem({ children, onClick, className }: Props) {
 
   return (
     <li
-      className={`flex justify-between items-center rounded-md border-b p-6 hover:bg-slate-100${classString}`}
+      className={`flex justify-between items-center border-b p-6 hover:bg-slate-100${classString}`}
       onClick={onClick}
     >
       {children}

--- a/app/(dashboard)/properties/[id]/components/expense-row.test.tsx
+++ b/app/(dashboard)/properties/[id]/components/expense-row.test.tsx
@@ -2,198 +2,61 @@ import { render, screen, waitFor } from '@testing-library/react';
 import ExpenseRow from './expense-row';
 import { describe, it, vi, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
+import * as actions from '../actions';
 import { Expense } from 'models/types';
-import { Frequency } from '@prisma/client';
 
 describe('ExpenseRow', () => {
   const mockExpense: Expense = {
     id: 1,
     name: 'Utilities',
     amount: 150,
-    frequency: Frequency.monthly
+    frequency: 'monthly'
   };
-
-  const mockOnDelete = vi.fn();
-  const mockOnSave = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders expense details correctly', () => {
-    render(
-      <ExpenseRow
-        expense={mockExpense}
-        onDelete={mockOnDelete}
-        onSave={mockOnSave}
-      />
-    );
+  it('renders expense details', () => {
+    render(<ExpenseRow expense={mockExpense} />);
 
-    expect(screen.getByText(/name:/i).parentNode).toHaveTextContent(
-      'Name: Utilities'
-    );
-    expect(screen.getByText(/amount:/i).parentNode).toHaveTextContent(
-      'Amount: $150'
-    );
-    expect(screen.getByText(/frequency:/i).parentNode).toHaveTextContent(
-      'Frequency: monthly'
-    );
+    expect(screen.getByText(/utilities/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$150/i)).toBeInTheDocument();
+    expect(screen.getByText(/monthly/i)).toBeInTheDocument();
   });
 
-  it('calls onDelete when Delete button is clicked', async () => {
+  it('toggles to edit mode when Edit is clicked', async () => {
     const user = userEvent.setup();
 
-    render(
-      <ExpenseRow
-        expense={mockExpense}
-        onDelete={mockOnDelete}
-        onSave={mockOnSave}
-      />
-    );
-
-    await user.click(screen.getByRole('button', { name: /delete/i }));
-
-    expect(mockOnDelete).toHaveBeenCalledWith(mockExpense.id);
-    expect(mockOnDelete).toHaveBeenCalledTimes(1);
-  });
-
-  it('enters edit mode and displays form fields', async () => {
-    const user = userEvent.setup();
-
-    render(
-      <ExpenseRow
-        expense={mockExpense}
-        onDelete={mockOnDelete}
-        onSave={mockOnSave}
-      />
-    );
+    render(<ExpenseRow expense={mockExpense} />);
 
     await user.click(screen.getByRole('button', { name: /edit/i }));
 
-    expect(screen.getByLabelText(/name/i)).toHaveValue('Utilities');
-    expect(screen.getByLabelText(/amount/i)).toHaveValue(150);
-    expect(screen.getByLabelText(/frequency/i)).toHaveValue('monthly');
-  });
-
-  it('updates the form state when inputs are changed', async () => {
-    const user = userEvent.setup();
-
-    render(
-      <ExpenseRow
-        expense={mockExpense}
-        onDelete={mockOnDelete}
-        onSave={mockOnSave}
-      />
-    );
-
-    await user.click(screen.getByRole('button', { name: /edit/i }));
-
-    const nameInput = screen.getByLabelText(/name/i);
-    const amountInput = screen.getByLabelText(/amount/i);
-    const frequencySelect = screen.getByLabelText(/frequency/i);
-
-    await user.clear(nameInput);
-    await user.type(nameInput, 'Updated Utilities');
-    await user.clear(amountInput);
-    await user.type(amountInput, '200');
-    await user.selectOptions(frequencySelect, 'yearly');
-
-    expect(nameInput).toHaveValue('Updated Utilities');
-    expect(amountInput).toHaveValue(200);
-    expect(frequencySelect).toHaveValue('yearly');
-  });
-
-  it('submits the form and calls onSave with form data', async () => {
-    const user = userEvent.setup();
-    mockOnSave.mockResolvedValue(undefined); // Simulate successful save
-
-    render(
-      <ExpenseRow
-        expense={mockExpense}
-        onDelete={mockOnDelete}
-        onSave={mockOnSave}
-      />
-    );
-
-    await user.click(screen.getByRole('button', { name: /edit/i }));
-
-    const nameInput = screen.getByLabelText(/name/i);
-    const amountInput = screen.getByLabelText(/amount/i);
-    const frequencySelect = screen.getByLabelText(/frequency/i);
-
-    await user.clear(nameInput);
-    await user.type(nameInput, 'Updated Utilities');
-    await user.clear(amountInput);
-    await user.type(amountInput, '200');
-    await user.selectOptions(frequencySelect, 'yearly');
-
-    await user.click(screen.getByRole('button', { name: /save/i }));
-
-    await waitFor(() => {
-      expect(mockOnSave).toHaveBeenCalledWith(expect.any(FormData));
-    });
-
-    // Ensure form submission exits edit mode
-    expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/name:/i).parentNode).toHaveTextContent(
-      'Name: Utilities'
-    );
-  });
-
-  it('displays an error message when save fails', async () => {
-    const user = userEvent.setup();
-    mockOnSave.mockRejectedValue(new Error('Failed to save expense'));
-
-    render(
-      <ExpenseRow
-        expense={mockExpense}
-        onDelete={mockOnDelete}
-        onSave={mockOnSave}
-      />
-    );
-
-    await user.click(screen.getByRole('button', { name: /edit/i }));
-    await user.click(screen.getByRole('button', { name: /save/i }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/failed to save the expense/i)
-      ).toBeInTheDocument();
-    });
-
-    // Ensure edit mode is not exited on failure
     expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
   });
 
-  it('resets form state and exits edit mode on Cancel', async () => {
+  it('calls editExpense on save', async () => {
     const user = userEvent.setup();
+    vi.spyOn(actions, 'updateExpense').mockResolvedValue({} as Expense);
 
-    render(
-      <ExpenseRow
-        expense={mockExpense}
-        onDelete={mockOnDelete}
-        onSave={mockOnSave}
-      />
-    );
+    render(<ExpenseRow expense={mockExpense} />);
 
     await user.click(screen.getByRole('button', { name: /edit/i }));
+    await user.click(screen.getByRole('button', { name: /save/i }));
 
-    const nameInput = screen.getByLabelText(/name/i);
-    const amountInput = screen.getByLabelText(/amount/i);
+    await waitFor(() => {
+      expect(actions.updateExpense).toHaveBeenCalledWith(expect.any(FormData));
+    });
+  });
 
-    await user.clear(nameInput);
-    await user.type(nameInput, 'Updated Utilities');
-    await user.clear(amountInput);
-    await user.type(amountInput, '200');
+  it('calls deleteExpense on delete', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(actions, 'deleteExpense').mockResolvedValue(undefined);
 
-    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    render(<ExpenseRow expense={mockExpense} />);
 
-    expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/name:/i).parentNode).toHaveTextContent(
-      'Name: Utilities'
-    );
-    expect(screen.getByText(/amount:/i).parentNode).toHaveTextContent(
-      'Amount: $150'
-    );
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+
+    expect(actions.deleteExpense).toHaveBeenCalledWith(mockExpense.id);
   });
 });

--- a/app/(dashboard)/properties/[id]/components/expense-row.tsx
+++ b/app/(dashboard)/properties/[id]/components/expense-row.tsx
@@ -20,12 +20,8 @@ function ExpenseRow({ expense, editingByDefault = false }: Props) {
   };
 
   const handleSave = async (formData: FormData) => {
-    try {
-      await updateExpense(formData);
-      setIsEditing(false);
-    } catch {
-      throw new Error('Failed to update the expense. Please try again.');
-    }
+    await updateExpense(formData);
+    setIsEditing(false);
   };
 
   const handleDelete = async () => {

--- a/app/(dashboard)/properties/[id]/components/expenses-section.test.tsx
+++ b/app/(dashboard)/properties/[id]/components/expenses-section.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ExpensesSection from './expenses-section';
+import { describe, it, vi, expect, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import * as actions from '../actions';
+import { Expense } from 'models/types';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: '1' })
+}));
+
+describe('ExpensesSection', () => {
+  const mockExpenses: Expense[] = [
+    { id: 1, name: 'Utilities', amount: 150, frequency: 'monthly' },
+    { id: 2, name: 'Insurance', amount: 100, frequency: 'yearly' }
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders expenses list', () => {
+    render(<ExpensesSection expenses={mockExpenses} />);
+
+    expect(screen.getByText(/utilities/i)).toBeInTheDocument();
+    expect(screen.getByText(/insurance/i)).toBeInTheDocument();
+  });
+
+  it('displays add expense form when Add Expense is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesSection expenses={mockExpenses} />);
+
+    await user.click(screen.getByRole('button', { name: /add expense/i }));
+
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+  });
+
+  it('calls createExpense on form submission', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(actions, 'createExpense').mockResolvedValue({} as Expense);
+
+    render(<ExpensesSection expenses={mockExpenses} />);
+
+    await user.click(screen.getByRole('button', { name: /add expense/i }));
+
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(actions.createExpense).toHaveBeenCalledWith(expect.any(FormData));
+    });
+  });
+
+  it('hides add expense form on cancel', async () => {
+    const user = userEvent.setup();
+
+    render(<ExpensesSection expenses={mockExpenses} />);
+
+    await user.click(screen.getByRole('button', { name: /add expense/i }));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/(dashboard)/properties/[id]/components/expenses-section.tsx
+++ b/app/(dashboard)/properties/[id]/components/expenses-section.tsx
@@ -29,13 +29,9 @@ function ExpensesSection({ expenses }: Props) {
 
   const handleCreateExpense = async (formData: FormData) => {
     formData.set('propertyId', propertyId.toString());
-    try {
-      await createExpense(formData);
-      setIsAdding(false);
-      return;
-    } catch {
-      throw new Error('Failed to create the expense. Please try again.');
-    }
+
+    await createExpense(formData);
+    setIsAdding(false);
   };
 
   const handleCancelCreate = () => {
@@ -56,7 +52,7 @@ function ExpensesSection({ expenses }: Props) {
             <ExpenseListItem>
               <ExpenseForm
                 key="new-expense"
-                initialData={{ name: '', amount: 0, frequency: 'monthly' }}
+                initialData={{ frequency: 'monthly' }}
                 onCancel={handleCancelCreate}
                 primaryAction={{
                   label: 'Create',

--- a/app/(dashboard)/properties/[id]/components/expenses-section.tsx
+++ b/app/(dashboard)/properties/[id]/components/expenses-section.tsx
@@ -8,15 +8,30 @@ import {
 import { Button } from '@/components/ui/button';
 import { Expense } from 'models/types';
 import ExpenseRow from './expense-row';
-import { deleteExpense, editExpense } from '../actions';
+import { addExpense, deleteExpense, editExpense } from '../actions';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
 
 interface Props {
   expenses: Expense[];
 }
 
 function ExpensesSection({ expenses }: Props) {
-  const handleAddExpense = () => {
-    console.log('Add expense clicked');
+  const params = useParams();
+  const propertyId = Number(params.id);
+
+  const handleAddExpense = async () => {
+    const formData = new FormData();
+    formData.set('propertyId', propertyId.toString());
+    formData.set('name', 'New Expense'); // Example default values
+    formData.set('amount', '0');
+    formData.set('frequency', 'monthly');
+
+    try {
+      await addExpense(formData);
+    } catch (error) {
+      console.error('Error adding expense:', error);
+    }
   };
 
   const onSave = async (formData: FormData) => {
@@ -24,7 +39,11 @@ function ExpensesSection({ expenses }: Props) {
   };
 
   const onDelete = async (id: number) => {
-    await deleteExpense(id);
+    try {
+      await deleteExpense(id);
+    } catch (error) {
+      console.error('Error deleting expense:', error);
+    }
   };
 
   return (
@@ -34,7 +53,7 @@ function ExpensesSection({ expenses }: Props) {
       </CardHeader>
       <CardContent>
         {expenses.length > 0 ? (
-          <ul className="space-y-4">
+          <ul>
             {expenses.map((expense) => (
               <ExpenseRow
                 key={expense.id}

--- a/app/(dashboard)/properties/[id]/components/expenses-section.tsx
+++ b/app/(dashboard)/properties/[id]/components/expenses-section.tsx
@@ -8,42 +8,38 @@ import {
 import { Button } from '@/components/ui/button';
 import { Expense } from 'models/types';
 import ExpenseRow from './expense-row';
-import { addExpense, deleteExpense, editExpense } from '../actions';
-import { useEffect, useState } from 'react';
+import { createExpense } from '../actions';
+import { useState } from 'react';
 import { useParams } from 'next/navigation';
+import ExpenseForm from './expense-form';
+import ExpenseListItem from './expense-list-item';
 
 interface Props {
   expenses: Expense[];
 }
 
 function ExpensesSection({ expenses }: Props) {
+  const [isAdding, setIsAdding] = useState(false);
   const params = useParams();
   const propertyId = Number(params.id);
 
-  const handleAddExpense = async () => {
-    const formData = new FormData();
+  const handleAddExpense = () => {
+    setIsAdding(true);
+  };
+
+  const handleCreateExpense = async (formData: FormData) => {
     formData.set('propertyId', propertyId.toString());
-    formData.set('name', 'New Expense'); // Example default values
-    formData.set('amount', '0');
-    formData.set('frequency', 'monthly');
-
     try {
-      await addExpense(formData);
-    } catch (error) {
-      console.error('Error adding expense:', error);
+      await createExpense(formData);
+      setIsAdding(false);
+      return;
+    } catch {
+      throw new Error('Failed to create the expense. Please try again.');
     }
   };
 
-  const onSave = async (formData: FormData) => {
-    await editExpense(formData);
-  };
-
-  const onDelete = async (id: number) => {
-    try {
-      await deleteExpense(id);
-    } catch (error) {
-      console.error('Error deleting expense:', error);
-    }
+  const handleCancelCreate = () => {
+    setIsAdding(false);
   };
 
   return (
@@ -52,25 +48,31 @@ function ExpensesSection({ expenses }: Props) {
         <h2 className="text-lg font-bold">Expenses</h2>
       </CardHeader>
       <CardContent>
-        {expenses.length > 0 ? (
-          <ul>
-            {expenses.map((expense) => (
-              <ExpenseRow
-                key={expense.id}
-                expense={expense}
-                onDelete={onDelete}
-                onSave={onSave}
+        <ul>
+          {expenses.map((expense) => (
+            <ExpenseRow key={expense.id} expense={expense} />
+          ))}
+          {isAdding && (
+            <ExpenseListItem>
+              <ExpenseForm
+                key="new-expense"
+                initialData={{ name: '', amount: 0, frequency: 'monthly' }}
+                onCancel={handleCancelCreate}
+                primaryAction={{
+                  label: 'Create',
+                  action: handleCreateExpense
+                }}
               />
-            ))}
-          </ul>
-        ) : (
-          <p>No expenses added.</p>
-        )}
+            </ExpenseListItem>
+          )}
+        </ul>
       </CardContent>
       <CardFooter>
-        <Button onClick={handleAddExpense} size="sm" variant="outline">
-          Add Expense
-        </Button>
+        {!isAdding && (
+          <Button onClick={handleAddExpense} size="sm" variant="outline">
+            Add Expense
+          </Button>
+        )}
       </CardFooter>
     </Card>
   );

--- a/models/validation-error.ts
+++ b/models/validation-error.ts
@@ -1,0 +1,6 @@
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,9 @@ export default {
           foreground: 'hsl(var(--card-foreground))'
         }
       },
+      fontSize: {
+        sm: '0.8125rem'
+      },
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
Updates styling of the expenses section and adds the ability to create a new expense:

<img width="1207" alt="Screenshot 2024-11-22 at 8 34 14 AM" src="https://github.com/user-attachments/assets/bff92977-61e9-433e-ace4-3544809ce70d">

After add expense is clicked:

<img width="1215" alt="Screenshot 2024-11-22 at 8 35 15 AM" src="https://github.com/user-attachments/assets/c0cf702e-057a-4716-9994-43c7102cc0c0">
